### PR TITLE
rppal upgrade to 0.11

### DIFF
--- a/tide-clock/Cargo.lock
+++ b/tide-clock/Cargo.lock
@@ -808,12 +808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,12 +935,12 @@ dependencies = [
 
 [[package]]
 name = "rppal"
-version = "0.9.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154df4b7b87fdb9d0032c7af1b45f47247a4585b7ae71c06f2d3e1d152d3650"
+checksum = "137dbba1fb867daa27cda4c3cd6a11bca5bb5a1551f034cf9319b994846ddbe1"
 dependencies = [
+ "lazy_static",
  "libc",
- "quick-error",
 ]
 
 [[package]]

--- a/tide-clock/Cargo.toml
+++ b/tide-clock/Cargo.toml
@@ -19,4 +19,4 @@ tokio = { version = "0.2", features = ["full"] }
 simple-error = "0.1.9"
 
 [target.'cfg(target_arch="arm")'.dependencies]
-rppal = "0.9.0"
+rppal = "0.11"

--- a/tide-clock/src/main.rs
+++ b/tide-clock/src/main.rs
@@ -6,10 +6,16 @@ use tides::{TideModel, TideModelWindow};
 mod display;
 mod font;
 mod maths;
+mod tides;
+use display::{GraphCanvas, Painter, RenderDevice, TextField, WaterMark};
+
+// When cross-compiling, use display emulation. When compiling
+// for target hardware, use the actual hardware. XXX This might
+// be better as a feature flag?
+#[cfg(not(target_arch = "arm"))]
+use display::ImageWriter;
 #[cfg(target_arch = "arm")]
 mod ssd1305;
-mod tides;
-use display::{GraphCanvas, ImageWriter, Painter, RenderDevice, TextField, WaterMark};
 
 const MAX_RETRIES: i32 = 3;
 

--- a/tide-clock/src/ssd1305.rs
+++ b/tide-clock/src/ssd1305.rs
@@ -1,5 +1,4 @@
 use std::thread;
-use std::error::Error;
 use std::time::Duration;
 use rppal::gpio::{self, Gpio};
 use rppal::spi::{Bus, Mode, SlaveSelect, Spi};


### PR DESCRIPTION
This patch upgrades `rppal` to 0.11. Includes the compiler warning fixes also included in the other patch.